### PR TITLE
Fixed "setupkey: [*Lib/Conversation/EnableWiki] now '1'" at startup

### DIFF
--- a/src/sup_main.cpp
+++ b/src/sup_main.cpp
@@ -702,7 +702,11 @@ namespace SUP
 		commandHandler.setMainForm(hWnd);
 
 		hideAdsChanged();
-		chatFormatChanged();
+
+		// At Skype startup value of Lib/Conversation/EnableWiki is 1,
+		// so no need to update if user has disabled "Disable Chat Formatting" option
+		if (!enableChatFormat)
+			chatFormatChanged();
 
 		MSG msg;
 		while (GetMessage(&msg, NULL, 0, 0))


### PR DESCRIPTION
Fixed "setupkey: [*Lib/Conversation/EnableWiki] now '1'" at startup if user has disabled "Disable Chat Formatting" option. It's redundant because Skype always reset it to 1 at startup.
